### PR TITLE
Add two more sections to the template

### DIFF
--- a/cip-template.md
+++ b/cip-template.md
@@ -34,3 +34,15 @@ All CIPs must contain a section that discusses the security
 implications/considerations relevant to the proposed change. Include
 possible attack vectors or ways this change could cause problems
 down the road.
+
+## Alternate designs considered
+Provide a list of other ideas that you considered and their pros and cons.
+This will help community understand the constraints under which other ideas were
+not chosen.
+
+## Data Storage Change
+Identify the additional storage requirement in the blockchain due to this change.
+
+## Acknowledgements
+If there were additional community members that helped you guide / hone your
+thoughts, or members whose feedback was constructive to make this CIP better.

--- a/cip-template.md
+++ b/cip-template.md
@@ -40,9 +40,6 @@ Provide a list of other ideas that you considered and their pros and cons.
 This will help community understand the constraints under which other ideas were
 not chosen.
 
-## Data Storage Change
-Identify the additional storage requirement in the blockchain due to this change.
-
 ## Acknowledgements
 If there were additional community members that helped you guide / hone your
-thoughts, or members whose feedback was constructive to make this CIP better.
+thoughts, or members who gave constructive feedback to make this CIP better.

--- a/cip-template.md
+++ b/cip-template.md
@@ -24,7 +24,7 @@ The technical specification should describe the new feature in deep technical de
 Include the rationale behind any decisions. If there were any approaches that didn't work, feel free to explain them to help future devs understand why things are the way they are.
  
 ### Data Storage Change
-Identify the additional storage requirement in the blockchain due to this change. Carefully consider if this CIP is creating additional duplication or if there are opportunity to optimize increase in size due to this CIP.
+Identify any additional storage requirements in the blockchain due to this change. Carefully consider if there are opportunities to optimize storage requirements.
 
 ## Backwards Compatibility
 All CIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The CIP must explain how the author proposes to deal with these incompatibilities.

--- a/cip-template.md
+++ b/cip-template.md
@@ -22,6 +22,9 @@ Include an explanation of the "why" behind this CIP. What problem does it solve?
 The technical specification should describe the new feature in deep technical detail. It should be detailed enough to allow for complete implementation.
   
 Include the rationale behind any decisions. If there were any approaches that didn't work, feel free to explain them to help future devs understand why things are the way they are.
+ 
+### Data Storage Change
+Identify the additional storage requirement in the blockchain due to this change. Carefully consider if this CIP is creating additional duplication or if there are opportunity to optimize increase in size due to this CIP.
 
 ## Backwards Compatibility
 All CIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The CIP must explain how the author proposes to deal with these incompatibilities.


### PR DESCRIPTION
Can we add three more sections to the template?

1) Alternate designs - Gives the community idea on why some design choices were skipped. 
2) Data storage change - As more fields are added, we need to start ensuring these new fields don't increase gas fees so much (as well as making nodes disk heavy).
3) Acknowledgements - People often have others who contributed, but not authors. This is a better place to ensure proper crediting?